### PR TITLE
Add comment feature from action instead of use externally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,161 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+create 
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/#use-with-ide
+.pdm.toml
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+.env
+.status.log
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+#.idea/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Define the test files
-TEST_FILES := test_upload_binary.py test_utils.py
+TEST_FILES := test_upload_binary.py test_utils.py test_github_utils.py
 
 # Define the default target
 .PHONY: test

--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ By default, the asset version will be assigned the existing values for Business 
 | version                           | The name of the asset version that will be created                                                                                                  | `true`   | `string`   |         |
 | file-path                         | Local path of the file to be uploaded                                                                                                                   | `true`   | `string`   |         |
 | quick-scan                        | Boolean that uploads the file for quick scan when true. Defaults to true (Quick Scan). For details about the contents of the Quick Scan vs. the Full Scan, please see the API documentation. | `false`   | `boolean`   | `true`    |
-| automatic-comment | Defaults to false. If it is true, it will generate a comment in the PR with the link to the Asset version URL in Finite State. | `false`  | `boolean`   | `false` |
-| github-token | Token used to generate comment in a pr. Only required if automatic-comment input is true. | `false` | `string`   |  |
+| automatic-comment | Defaults to false. If it is true, it will generate a comment in the PR with the link to the Asset version URL in the Finite State Platform. | `false`  | `boolean`   | `false` |
+| github-token | Token used to generate a comment in a the PR. Only required if automatic-comment input is true. | `false` | `string`   |  |
 | business-unit-id                  | (optional) ID of the business unit that the asset version will belong to. If not provided, the asset version will adopt the existing business unit of the asset.                | `false`  | `string`   |         |
 | created-by-user-id                | (optional) ID of the user to be recorded as the 'Created By User' on the asset version. If not provided, the  version will adopt the existing value of the asset.            | `false`  | `string`   |         |
 | product-id                        | (optional) ID of the product that the asset version will belong to. If not provided, the existing product for the asset will be used, if applicable.              | `false`  | `string`   |         |
@@ -90,7 +90,7 @@ You will also need to add your code into the workflow. The example only includes
 **Example:** 
 
 ```yaml
-uses: FiniteStateInc/binary-scan@v1.0.0
+uses: FiniteStateInc/binary-scan@v1.1.0
 with:
   finite-state-client-id: ${{ secrets.CLIENT_ID }}
   finite-state-secret: ${{ secrets.CLIENT_SECRET }}
@@ -101,12 +101,12 @@ with:
 ```
 Using the previous code you won't get any comments in the pull request, but file will be upload to Finite State Platform and you get the link as output of the action.
 
-### Auto generation of comments
-The following example includes optional parameters `github-token` and `automatic-comment` to auto generate a comment in a pull request:
+### Auto-Generation of PR Comments
+The following example includes optional parameters `github-token` and `automatic-comment` to auto-generate a comment in a pull request:
 
 **Example:**
 ```yaml
-uses: FiniteStateInc/binary-scan@v1.0.0
+uses: FiniteStateInc/binary-scan@v1.1.0
 with:
   finite-state-client-id: ${{ secrets.CLIENT_ID }}
   finite-state-secret: ${{ secrets.CLIENT_SECRET }}
@@ -114,8 +114,8 @@ with:
   asset-id:  # The ID of the Asset associated with this scan
   version:   # The name of the new Asset Version that will be created
   file-path: # The path to the file that will be uploaded to the Finite State Platform
-  github-token: ${{ secrets.GITHUB_TOKEN }} # optional if you would like to generate the comment automatically in the PR
-  automatic-comment: true # optional if you would like to generate the comment automatically in the PR
+  github-token: ${{ secrets.GITHUB_TOKEN }} # Optional if you would like to generate the comment automatically in the PR
+  automatic-comment: true # Optional if you would like to generate the comment automatically in the PR
 ```
 
 ## Action Debugging
@@ -172,7 +172,7 @@ jobs:
           echo "COMMIT_HASH=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
       - name: Binary Scan
-        uses: FiniteStateInc/binary-scan@v1.0.0
+        uses: FiniteStateInc/binary-scan@v1.1.0
         id: binary_scan
         with:
           finite-state-client-id: ${{ secrets.CLIENT_ID }}

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ By default, the asset version will be assigned the existing values for Business 
 | version                           | The name of the asset version that will be created                                                                                                  | `true`   | `string`   |         |
 | file-path                         | Local path of the file to be uploaded                                                                                                                   | `true`   | `string`   |         |
 | quick-scan                        | Boolean that uploads the file for quick scan when true. Defaults to true (Quick Scan). For details about the contents of the Quick Scan vs. the Full Scan, please see the API documentation. | `false`   | `boolean`   | `true`    |
+| automatic-comment | Defaults to false. If it is true, it will generate a comment in the PR with the link to the Asset version URL in Finite State. | `false`  | `boolean`   | `false` |
+| github-token | Token used to generate comment in a pr. Only required if automatic-comment input is true. | `false` | `string`   |  |
 | business-unit-id                  | (optional) ID of the business unit that the asset version will belong to. If not provided, the asset version will adopt the existing business unit of the asset.                | `false`  | `string`   |         |
 | created-by-user-id                | (optional) ID of the user to be recorded as the 'Created By User' on the asset version. If not provided, the  version will adopt the existing value of the asset.            | `false`  | `string`   |         |
 | product-id                        | (optional) ID of the product that the asset version will belong to. If not provided, the existing product for the asset will be used, if applicable.              | `false`  | `string`   |         |
@@ -69,6 +71,18 @@ on:
     - cron: "0 0 * * *"
 ```
 
+If you want the PR to automatically generate a comment with the link to the results on the Finite State Platform, make sure to grant the necessary permissions in your workflow. This allows the action to post the comment using the GitHub workflow token.
+
+**Example**:
+
+```yaml
+name: Your workflow
+permissions:
+  pull-requests: write
+  contents: read
+
+```
+
 ## Usage of this Action
 
 You will also need to add your code into the workflow. The example only includes the required parameters. For more details, including optional parameters, please reference the **Inputs** section.
@@ -85,6 +99,24 @@ with:
   version:   # The name of the new Asset Version that will be created
   file-path: # The path to the file that will be uploaded to the Finite State Platform
 ```
+Using the previous code you won't get any comments in the pull request, but file will be upload to Finite State Platform and you get the link as output of the action.
+
+### Auto generation of comments
+The following example includes optional parameters `github-token` and `automatic-comment` to auto generate a comment in a pull request:
+
+**Example:**
+```yaml
+uses: FiniteStateInc/binary-scan@v1.0.0
+with:
+  finite-state-client-id: ${{ secrets.CLIENT_ID }}
+  finite-state-secret: ${{ secrets.CLIENT_SECRET }}
+  finite-state-organization-context:  ${{ secrets.ORGANIZATION_CONTEXT }}
+  asset-id:  # The ID of the Asset associated with this scan
+  version:   # The name of the new Asset Version that will be created
+  file-path: # The path to the file that will be uploaded to the Finite State Platform
+  github-token: ${{ secrets.GITHUB_TOKEN }} # optional if you would like to generate the comment automatically in the PR
+  automatic-comment: true # optional if you would like to generate the comment automatically in the PR
+```
 
 ## Action Debugging
 
@@ -94,15 +126,15 @@ All details pertaining to the execution of the action will be recorded. You can 
 
 ## Extended Feature Example (Optional)
 
-In this section, we provide a code snippet for integrating this action into your existing workflow. Primarily, it uploads the file to the Finite State Platform for analysis. Once that process is complete, it uses the output of that job to automatically add a comment to the pull request, including a link pointing to the Finite State Binary Analysis URL for the uploaded file. You can customize the comment as desired or utilize the outputs of the action to construct your own.
-
-The job, named `show-link-as-comment`, is responsible for generating the comment using the output provided by the action.
+In this section, we provide a code snippet for integrating this action into your existing workflow. Primarily, it uploads the file to the Finite State Platform for analysis. Once that process is complete, it automatically add a comment to the pull request, including a link pointing to the Finite State Binary Analysis URL for the uploaded file. You can customize the comment as desired or utilize the outputs of the action to construct your own.
 
 Ensure to replace certain values, as indicated in the example workflow:
 
 ```yaml
 name: Build
-
+permissions:
+  pull-requests: write
+  contents: read
 on:
   pull_request:
     branches:
@@ -149,7 +181,8 @@ jobs:
           asset-id: ${{env.ASSET_ID}}
           version: ${{env.COMMIT_HASH}} # You can name this version anything you'd like. Here, we're using the git commit hash associated with the current run.
           file-path: # Put the same path from the "Upload binary generated file" step here
-
+          github-token: ${{ secrets.GITHUB_TOKEN }} # optional if you would like to generate the comment automatically in the PR
+          automatic-comment: true # optional if you would like to generate the comment automatically in the PR
       - name: Set response of binary scan
         if: steps.binary_scan.outcome=='success'
         id: set_response
@@ -161,22 +194,3 @@ jobs:
       ASSET_VERSION_URL: ${{steps.binary_scan.outputs.asset-version-url}}
       ERROR: ${{steps.binary_scan.outputs.error}}
       RESPONSE: ${{steps.binary_scan.outputs.response}}
-
-  show-link-as-comment: # This job generates a comment automatically in the PR in order to link to the Finite State Platform
-    needs: finitestate-upload-binary
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-    steps:
-      - name: Add link to finitestate
-        uses: mshick/add-pr-comment@v2
-        with:
-          message: |
-            **Hello**, Finite State is analyzing your files! :rocket:. 
-            Please <a href="${{needs.finitestate-upload-binary.outputs.ASSET_VERSION_URL}}">click here</a> to see the progress of the analysis.
-            <br />
-
-            <a href="https://platform.finitestate.io/">Finite State</a>
-          message-failure: |
-            **Hello**, We're sorry, but something went wrong. Please contact Finite State Support.
-            <a href="https://platform.finitestate.io/">Finite State</a>

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,13 @@ inputs:
     description: Boolean that uploads the file for quick scan when true. Defaults to true (Quick Scan). For details about the contents of the Quick Scan vs. the Full Scan, please see the API documentation. 
     required: true
     default: true
+  automatic-comment:
+    description: Defaults to false. If it is true, it will generate a comment in the PR with the link to the Asset version URL in Finite State.
+    required: false
+    default: false  
+  github-token:
+    description: Token used to generate comment in a pr. Only required if automatic-comment input is true.
+    required: false
   business-unit-id:
     description: '(optional) ID of the business unit that the asset version will belong to. If not provided, the asset version will adopt the existing business unit of the asset.'
     required: false

--- a/github_utils.py
+++ b/github_utils.py
@@ -1,0 +1,46 @@
+import os
+import requests
+import json
+import re
+
+
+def extract_pull_request_number():
+    if is_pull_request():
+        match = re.search(r"/pull/(\d+)/", os.environ.get("GITHUB_REF"))
+        if match:
+            return match.group(1)
+        else:
+            return None
+    return None
+
+
+def extract_repository_owner():
+    return os.environ.get("GITHUB_REPOSITORY_OWNER")
+
+
+def extract_repository_name():
+    GITHUB_REPOSITORY = os.environ.get("GITHUB_REPOSITORY")
+    if not GITHUB_REPOSITORY:
+        return None
+    # Split the URL using "/" and get the last element
+    parts = GITHUB_REPOSITORY.split("/")
+    if len(parts) >= 2:
+        return parts[-1]
+    else:
+        return None
+
+
+def is_pull_request():
+    return os.environ.get("GITHUB_EVENT_NAME") == "pull_request"
+
+
+def comment_on_pr(comment, github_token, pr_number, repo_owner, repo_name):
+    github_api_url = os.environ.get("GITHUB_API_URL")
+    url = f"{github_api_url}/repos/{repo_owner}/{repo_name}/issues/{pr_number}/comments"
+    headers = {
+        "Authorization": f"token {github_token}",
+        "Accept": "application/vnd.github.v3+json",
+    }
+    data = {"body": comment}
+    response = requests.post(url, headers=headers, data=json.dumps(data))
+    return response

--- a/test_github_utils.py
+++ b/test_github_utils.py
@@ -1,0 +1,52 @@
+import unittest
+from unittest.mock import patch
+import os
+from github_utils import (
+    extract_pull_request_number,
+    extract_repository_owner,
+    extract_repository_name,
+    is_pull_request,
+    comment_on_pr,
+)
+
+
+class TestGithubUtils(unittest.TestCase):
+    @patch.dict(
+        os.environ,
+        {"GITHUB_EVENT_NAME": "pull_request", "GITHUB_REF": "refs/pull/42/merge"},
+    )
+    def test_extract_pull_request_number(self):
+        result = extract_pull_request_number()
+        self.assertEqual(result, "42")
+
+    @patch.dict(os.environ, {"GITHUB_REPOSITORY_OWNER": "owner"})
+    def test_extract_repository_owner(self):
+        result = extract_repository_owner()
+        self.assertEqual(result, "owner")
+
+    @patch.dict(os.environ, {"GITHUB_REPOSITORY": "owner/repo"})
+    def test_extract_repository_name(self):
+        result = extract_repository_name()
+        self.assertEqual(result, "repo")
+
+    @patch.dict(os.environ, {"GITHUB_EVENT_NAME": "pull_request"})
+    def test_is_pull_request(self):
+        result = is_pull_request()
+        self.assertTrue(result)
+
+    @patch("requests.post", return_value="mocked_response")
+    @patch.dict(
+        os.environ,
+        {"GITHUB_API_URL": "https://api.github.com", "GITHUB_TOKEN": "your_token"},
+    )
+    def test_comment_on_pr(self, mock_post):
+        comment = "Test comment"
+        pr_number = "42"
+        repo_owner = "owner"
+        repo_name = "repo"
+        result = comment_on_pr(comment, "your_token", pr_number, repo_owner, repo_name)
+        self.assertEqual(result, "mocked_response")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_utils.py
+++ b/test_utils.py
@@ -1,6 +1,11 @@
 import unittest
 from unittest.mock import patch, mock_open
-from utils import set_multiline_output, set_output, extract_asset_version
+from utils import (
+    set_multiline_output,
+    set_output,
+    extract_asset_version,
+    generate_comment,
+)
 
 
 class TestUtilsFunctions(unittest.TestCase):

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,13 @@
 import uuid
 import re
 import os
+from github_utils import (
+    extract_pull_request_number,
+    extract_repository_owner,
+    extract_repository_name,
+    comment_on_pr,
+    is_pull_request,
+)
 
 
 def set_multiline_output(name, value):
@@ -29,3 +36,27 @@ def extract_asset_version(input_string):
         return asset_version_value
     else:
         return None  # Return None if asset version value is not found
+
+
+def generate_comment(github_token, asset_version_url, logger):
+    pull_request_number = extract_pull_request_number()
+    repo_owner = extract_repository_owner()
+    repo_name = extract_repository_name()
+    comment = (
+        "**Hello**, Finite State is analyzing your files! :rocket:. \n"
+        "Please, [click here]({asset_version_url}) to see the progress of the analysis."
+        "<br />\n"
+        "[Finite State](https://platform.finitestate.io/)"
+    )
+
+    formatted_comment = comment.format(asset_version_url=asset_version_url)
+    response = comment_on_pr(
+        formatted_comment, github_token, pull_request_number, repo_owner, repo_name
+    )
+    if response.status_code == 201:
+        logger.info("Comment posted successfully")
+    else:
+        logger.error(
+            f"Failed to post comment. Status code: {response.status_code} {response.text}"
+        )
+        logger.debug(response)


### PR DESCRIPTION
 ## We should merge this to main when we would like to release a new version with this new feature.

This PR add the feature to add a comment from python instead of manage from external workflow.
Outputs of script didn't change so you have the option to use the asset version url to do your custom actions.

